### PR TITLE
Fix JSON parse error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,13 @@
 class TaskManager {
     constructor() {
-        this.tasks = JSON.parse(localStorage.getItem('tasks')) || [];
+        try {
+            const saved = localStorage.getItem('tasks');
+            this.tasks = saved ? JSON.parse(saved) : [];
+        } catch (e) {
+            console.error('Error loading tasks from localStorage', e);
+            this.tasks = [];
+            localStorage.removeItem('tasks');
+        }
         this.filters = {
             all: () => true,
             pending: (task) => !task.completed,


### PR DESCRIPTION
## Summary
- handle corrupted localStorage data gracefully in TaskManager constructor

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_6841ecf3a67c8327855570338fa9fe27